### PR TITLE
Fixed manifest not reloading during dev watch task

### DIFF
--- a/src/build/templates/tasks/es5/manifest.js
+++ b/src/build/templates/tasks/es5/manifest.js
@@ -1,5 +1,4 @@
 var gulp = require('gulp')
-  , manifest = require('../app/manifest.json')
   , assign = require('object-assign')
   , fs = require('fs')
   , version = require('../package.json').version
@@ -18,6 +17,8 @@ gulp.task('manifest:prod', function(done) {
 })
 
 function build(done, extra) {
+  delete require.cache[require.resolve('../app/manifest.json')]
+  var manifests= require('../app/manifest.json')
   var mani = assign({}, manifest, { version: version }, extra)
     , json = JSON.stringify(mani, null, ' ')
     , dist = path.resolve(__dirname, '..', 'dist')

--- a/src/build/templates/tasks/es6/manifest.js
+++ b/src/build/templates/tasks/es6/manifest.js
@@ -1,12 +1,10 @@
 <% if (modules === 'es6') { -%>
 import gulp from 'gulp'
-import manifest from '../app/manifest.json'
 import { mkdir, writeFile } from 'fs'
 import { version } from '../package.json'
 import { resolve, join } from 'path'
 <% } else { -%>
 const gulp = require('gulp')
-    , manifest = require('../app/manifest.json')
   , { mkdir, writeFile } = require('fs')
   , { version } = require('../package.json')
   , { resolve, join } = require('path')
@@ -23,6 +21,8 @@ gulp.task('manifest:dev', (done) => {
 gulp.task('manifest:prod', (done) => build(done))
 
 function build(done, extra = {}) {
+  delete require.cache[require.resolve('../app/manifest.json')]
+  let manifest = require('../app/manifest.json')
   let mani = { ...manifest, version, ...extra }
     , json = JSON.stringify(mani, null, ' ')
     , dist = resolve(__dirname, '..', 'dist')


### PR DESCRIPTION
The manifest.js task (specifically manifest:dev) has a watch task to recompile the manifest whenever it is modified. However, because the manifest is imported at the top of the file, the manifest doesn't properly reload as you would expect (the import only reloads the file when the gulp tasks are being built). Moved importing the manifest to the actual build function (and deleting the require cache to force reload of the manifest file). 
